### PR TITLE
fix: add is_subcontracted check for additional validation/submit/cancel code

### DIFF
--- a/inventory_tools/inventory_tools/overrides/purchase_invoice.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_invoice.py
@@ -52,19 +52,19 @@ class InventoryToolsPurchaseInvoice(PurchaseInvoice):
 			)
 
 	def validate(self):
-		if self.is_work_order_subcontracting_enabled():
+		if self.is_work_order_subcontracting_enabled() and self.is_subcontracted:
 			if not self.supplier_warehouse:
 				self.supplier_warehouse = fetch_supplier_warehouse(self.company, self.supplier)
 			self.validate_subcontracting_to_pay_qty()
 		return super().validate()
 
 	def on_submit(self):
-		if self.is_work_order_subcontracting_enabled():
+		if self.is_work_order_subcontracting_enabled() and self.is_subcontracted:
 			self.on_submit_save_se_paid_qty()
 		return super().on_submit()
 
 	def on_cancel(self):
-		if self.is_work_order_subcontracting_enabled():
+		if self.is_work_order_subcontracting_enabled() and self.is_subcontracted:
 			self.on_cancel_revert_se_paid_qty()
 		return super().on_cancel()
 

--- a/inventory_tools/inventory_tools/overrides/purchase_order.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_order.py
@@ -76,7 +76,7 @@ class InventoryToolsPurchaseOrder(PurchaseOrder):
 				validate_warehouse_company(w, self.company)
 
 	def validate(self):
-		if self.is_work_order_subcontracting_enabled():
+		if self.is_work_order_subcontracting_enabled() and self.is_subcontracted:
 			self.validate_subcontracting_fg_qty()
 			for row in self.subcontracting:
 				# TODO: set work order supplier to empty string in on_cancel
@@ -90,7 +90,7 @@ class InventoryToolsPurchaseOrder(PurchaseOrder):
 
 	def validate_subcontracting_fg_qty(self):
 		sub_wo = self.get("subcontracting")
-		if self.is_subcontracted and sub_wo:
+		if sub_wo:
 			items_fg_qty = sum(item.get("fg_item_qty") or 0 for item in self.get("items"))
 			subc_fg_qty = sum(row.get("fg_item_qty") or 0 for row in sub_wo)
 			# Check that the item finished good qty and the subcontracting qty are within the item's stock_qty field's precision number of decimals


### PR DESCRIPTION
I triggered a validation error in non-subcontracted PI when I had the subcontracting work order feature enabled. The previous code only checked for the setting before running the additional validation/submit/cancel functions - this fix adds the check that the PO/PI has `is_subcontracted` checked as well.