### PR TITLE
ci: track overrides for purchase cycle (PO/PI/PR)

### DIFF
--- a/.github/workflows/overrides.yaml
+++ b/.github/workflows/overrides.yaml
@@ -1,0 +1,20 @@
+name: Track Overrides
+
+on:
+  pull_request:
+    branches:
+      - version-14
+      - version-15
+
+jobs:
+  track_overrides:
+    runs-on: ubuntu-latest
+    name: Track Overrides
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name:  Track Overrides
+        uses: diamorafaela/track-overrides@main
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/inventory_tools/inventory_tools/overrides/purchase_invoice.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_invoice.py
@@ -12,6 +12,12 @@ from frappe.utils.data import cint
 
 class InventoryToolsPurchaseInvoice(PurchaseInvoice):
 	def validate_with_previous_doc(self):
+		"""
+		HASH: 82d206b709ada758c277bc5a266dbc6ec10d00c8
+		REPO: https://github.com/frappe/erpnext/
+		PATH: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
+		METHOD: validate_with_previous_doc
+		"""
 		config = {
 			"Purchase Order": {
 				"ref_dn_field": "purchase_order",

--- a/inventory_tools/inventory_tools/overrides/purchase_order.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_order.py
@@ -25,6 +25,12 @@ def _bypass(*args, **kwargs):
 
 class InventoryToolsPurchaseOrder(PurchaseOrder):
 	def validate_with_previous_doc(self):
+		"""
+		HASH: 4d34b1ead73baf4c5430a2ecbe44b9e8468d7626
+		REPO: https://github.com/frappe/erpnext/
+		PATH: erpnext/buying/doctype/purchase_order/purchase_order.py
+		METHOD: validate_with_previous_doc
+		"""
 		config = {
 			"Supplier Quotation": {
 				"ref_dn_field": "supplier_quotation",
@@ -218,6 +224,12 @@ def make_sales_invoices(docname: str, rows: Union[list, str]) -> None:
 
 @frappe.whitelist()
 def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=True):
+	"""
+	HASH: 0bee921d402060abe6c06568dd3f600d1445719f
+	REPO: https://github.com/frappe/erpnext/
+	PATH: erpnext/stock/get_item_details.py
+	METHOD: get_item_details
+	"""
 	import erpnext.stock.get_item_details
 
 	erpnext.stock.get_item_details.validate_item_details = validate_item_details
@@ -229,6 +241,12 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 
 @frappe.whitelist()
 def validate_item_details(args, item):
+	"""
+	HASH: 0bee921d402060abe6c06568dd3f600d1445719f
+	REPO: https://github.com/frappe/erpnext/
+	PATH: erpnext/stock/get_item_details.py
+	METHOD: validate_item_details
+	"""
 	if not args.company:
 		throw(_("Please specify Company"))
 

--- a/inventory_tools/inventory_tools/overrides/purchase_receipt.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_receipt.py
@@ -10,6 +10,12 @@ from frappe.utils.data import cint
 
 class InventoryToolsPurchaseReceipt(PurchaseReceipt):
 	def validate_with_previous_doc(self):
+		"""
+		HASH: 9d0c1dc46f94e921eb108fcbfa24fbd776a710d3
+		REPO: https://github.com/frappe/erpnext/
+		PATH: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
+		METHOD: validate_with_previous_doc
+		"""
 		config = {
 			"Purchase Order": {
 				"ref_dn_field": "purchase_order",


### PR DESCRIPTION
Addresses #86 

I think I grabbed the right commit for each method/file (I checked the blame timeframes for the method in ERPNext's `version-14` branch to make sure nothing major changed recently, and used the most recent commit for the given file).

One discussion point - I did NOT include the tracking docstring in methods for `validate`/`on_cancel`/`on_submit` for these files because we weren't changing the ERPNext code in them. Our pattern adds other methods to call, then calls `super`. We should decide to:

a) keep code as-is, don't include tracking for that scenario (i.e. it how the current PR does it)
b) keep code as-is but include the tracking docstring to those methods
c) refactor the current code to call those methods via hooks' doc_events instead of overriding/adding our method calls/calling `super`, then we wouldn't need the tracking docstring 

