### PR TITLE
feat: replace global monkey patch get_item_details with PO method override

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,7 +16,6 @@ repos:
       - id: check-ast
       - id: check-json
       - id: check-toml
-      - id: check-yaml
       - id: debug-statements
 
   - repo: https://github.com/asottile/pyupgrade
@@ -25,7 +24,7 @@ repos:
       - id: pyupgrade
         args: ['--py310-plus']
 
-  - repo: https://github.com/frappe/black
+  - repo: https://github.com/agritheory/black
     rev: 951ccf4d5bb0d692b457a5ebc4215d755618eb68
     hooks:
       - id: black

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Set up a new bench, substitute a path to the python version to use, which should
 
 ```
 # for linux development
-bench init --frappe-branch version-14 {{ bench name }} --python ~/.pyenv/versions/3.10.10/bin/python3
+bench init --frappe-branch version-15 {{ bench name }} --python ~/.pyenv/versions/3.10.16/bin/python3
 ```
 Create a new site in that bench
 ```
@@ -23,13 +23,17 @@ cd {{ bench name }}
 bench new-site {{ site name }} --force --db-name {{ site name }}
 bench use {{ site name }}
 ```
-Download the ERPNext app
+Download the ERPNext app, other dependencies, and this application
 ```
-bench get-app erpnext --branch version-14
+bench get-app erpnext --branch version-15
+bench get-app hrms --branch version-15
+bench get-app payments --branch version-15
+bench get-app webshop --branch version-15
+bench get-app inventory_tools --branch version-15 git@github.com:agritheory/inventory_tools.git
 ```
-Download this application and install all apps
+Install all apps into the site
 ```
-bench get-app inventory_tools git@github.com:agritheory/inventory_tools.git
+bench install-app erpnext hrms payments webshop inventory_tools
 ```
 Set developer mode in `site_config.json`
 ```
@@ -66,5 +70,5 @@ mypy ./apps/inventory_tools/inventory_tools --ignore-missing-imports
 To run pytest
 ```shell
 source env/bin/activate
-pytest ~/frappe-bench/apps/inventory_tools/inventory_tools/tests -s
+pytest ./apps/inventory_tools/inventory_tools/tests -s
 ```

--- a/inventory_tools/__init__.py
+++ b/inventory_tools/__init__.py
@@ -2,20 +2,3 @@
 # For license information, please see license.txt
 
 __version__ = "15.1.0"
-
-
-"""
-This code loads a modified version of validate_item_details function. It's called from
-get_item_details, which is a whitelisted method called both client-side as well as
-server-side (in validation functions) for several doctypes. Because of the dual nature,
-two methods were needed to ensure the correct code runs in all scenarios: the standard
-override whitelisted method in hooks.py and the monkey patch below.
-
-The modification only applies when the Enable Work Order Subcontracting feature is selected in
-Inventory Tools Settings. If the feature is turned off, the default ERPNext behavior runs.
-"""
-import erpnext.stock.get_item_details
-
-from inventory_tools.inventory_tools.overrides.purchase_order import validate_item_details
-
-erpnext.stock.get_item_details.validate_item_details = validate_item_details

--- a/inventory_tools/inventory_tools/overrides/job_card.py
+++ b/inventory_tools/inventory_tools/overrides/job_card.py
@@ -12,7 +12,7 @@ from inventory_tools.inventory_tools.overrides.work_order import get_allowance_p
 class InventoryToolsJobCard(JobCard):
 	def validate_job_card(self):
 		"""
-		HASH: 6554f192fbe90033a71fa323462633c5130e1b46
+		HASH: 6c4655dd72dc304d07b2b23a26e7f61eb1ff00b9
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/job_card/job_card.py
 		METHOD: validate_job_card

--- a/inventory_tools/inventory_tools/overrides/production_plan.py
+++ b/inventory_tools/inventory_tools/overrides/production_plan.py
@@ -12,7 +12,7 @@ class InventoryToolsProductionPlan(ProductionPlan):
 	@frappe.whitelist()
 	def make_work_order(self):
 		"""
-		HASH: 30c0b2bb546c1c78bd5db29311a78d71a02efdf1
+		HASH: 539c5b7974ffdaf4caf8acb6d4acc00fba626668
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/production_plan/production_plan.py
 		METHOD: make_work_order
@@ -34,7 +34,7 @@ class InventoryToolsProductionPlan(ProductionPlan):
 
 	def make_work_order_for_subassembly_items(self, wo_list, subcontracted_po, default_warehouses):
 		"""
-		HASH: 30c0b2bb546c1c78bd5db29311a78d71a02efdf1
+		HASH: 539c5b7974ffdaf4caf8acb6d4acc00fba626668
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/production_plan/production_plan.py
 		METHOD: make_work_order_for_subassembly_items

--- a/inventory_tools/inventory_tools/overrides/purchase_invoice.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_invoice.py
@@ -12,7 +12,7 @@ from frappe.utils.data import cint
 class InventoryToolsPurchaseInvoice(PurchaseInvoice):
 	def validate_with_previous_doc(self):
 		"""
-		HASH: 183ac4155046dc5d18f9a28c560b7586c5f12b4b
+		HASH: e3855949e14d445fe6becfd2dae91fff9309ba42
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/accounts/doctype/purchase_invoice/purchase_invoice.py
 		METHOD: validate_with_previous_doc

--- a/inventory_tools/inventory_tools/overrides/purchase_order.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_order.py
@@ -5,6 +5,7 @@ import json
 import types
 
 import frappe
+from erpnext import get_default_cost_center
 from erpnext.accounts.doctype.sales_invoice.sales_invoice import (
 	make_inter_company_purchase_invoice,
 )
@@ -13,7 +14,11 @@ from erpnext.buying.doctype.purchase_order.purchase_order import (
 	make_purchase_invoice,
 	make_purchase_receipt,
 )
-from erpnext.controllers.accounts_controller import get_default_taxes_and_charges
+from erpnext.controllers.accounts_controller import (
+	get_default_taxes_and_charges,
+	force_item_fields,
+)
+from erpnext.stock.doctype.item.item import get_uom_conv_factor
 from erpnext.stock.utils import validate_disabled_warehouse, validate_warehouse_company
 from frappe import _, throw
 
@@ -25,7 +30,7 @@ def _bypass(*args, **kwargs):
 class InventoryToolsPurchaseOrder(PurchaseOrder):
 	def validate_with_previous_doc(self):
 		"""
-		HASH: 7cc5579ecaae99336b8164e7aeedc15b990d2257
+		HASH: 8f811728d97293744bb35f6a3bdba889708127c5
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/buying/doctype/purchase_order/purchase_order.py
 		METHOD: validate_with_previous_doc
@@ -105,6 +110,129 @@ class InventoryToolsPurchaseOrder(PurchaseOrder):
 					title=_("Warning"),
 					indicator="red",
 				)
+
+	def set_missing_item_details(self, for_validate=False):
+		"""
+		HASH: aef6b62f7d68520e7878497718c9ffc7502118e4
+		REPO: https://github.com/frappe/erpnext/
+		PATH: erpnext/controllers/accounts_controller.py
+		METHOD: set_missing_item_details
+		"""
+		from erpnext.stock.doctype.serial_no.serial_no import get_serial_nos
+
+		if hasattr(self, "items"):
+			parent_dict = {}
+			for fieldname in self.meta.get_valid_columns():
+				parent_dict[fieldname] = self.get(fieldname)
+
+			if self.doctype in ["Quotation", "Sales Order", "Delivery Note", "Sales Invoice"]:
+				document_type = f"{self.doctype} Item"
+				parent_dict.update({"document_type": document_type})
+
+			# party_name field used for customer in quotation
+			if (
+				self.doctype == "Quotation"
+				and self.quotation_to == "Customer"
+				and parent_dict.get("party_name")
+			):
+				parent_dict.update({"customer": parent_dict.get("party_name")})
+
+			self.pricing_rules = []
+
+			for item in self.get("items"):
+				if item.get("item_code"):
+					args = parent_dict.copy()
+					args.update(item.as_dict())
+
+					args["doctype"] = self.doctype
+					args["name"] = self.name
+					args["child_doctype"] = item.doctype
+					args["child_docname"] = item.name
+					args["ignore_pricing_rule"] = (
+						self.ignore_pricing_rule if hasattr(self, "ignore_pricing_rule") else 0
+					)
+
+					if not args.get("transaction_date"):
+						args["transaction_date"] = args.get("posting_date")
+
+					if self.get("is_subcontracted"):
+						args["is_subcontracted"] = self.is_subcontracted
+
+					# CUSTOM CODE START (uses overridden function defined below)
+					ret = get_item_details(args, self, for_validate=for_validate, overwrite_warehouse=False)
+					# CUSTOM CODE END
+					for fieldname, value in ret.items():
+						if item.meta.get_field(fieldname) and value is not None:
+							if (
+								item.get(fieldname) is None
+								or fieldname in force_item_fields
+								or (fieldname in ["serial_no", "batch_no"] and item.get("use_serial_batch_fields"))
+							):
+								item.set(fieldname, value)
+
+							elif fieldname in ["cost_center", "conversion_factor"] and not item.get(fieldname):
+								item.set(fieldname, value)
+							elif fieldname == "item_tax_rate" and not (
+								self.get("is_return") and self.get("return_against")
+							):
+								item.set(fieldname, value)
+							elif fieldname == "serial_no":
+								# Ensure that serial numbers are matched against Stock UOM
+								item_conversion_factor = item.get("conversion_factor") or 1.0
+								item_qty = abs(item.get("qty")) * item_conversion_factor
+
+								if item_qty != len(get_serial_nos(item.get("serial_no"))):
+									item.set(fieldname, value)
+
+							elif (
+								ret.get("pricing_rule_removed")
+								and value is not None
+								and fieldname
+								in [
+									"discount_percentage",
+									"discount_amount",
+									"rate",
+									"margin_rate_or_amount",
+									"margin_type",
+									"remove_free_item",
+								]
+							):
+								# reset pricing rule fields if pricing_rule_removed
+								item.set(fieldname, value)
+
+					if self.doctype in ["Purchase Invoice", "Sales Invoice"] and item.meta.get_field(
+						"is_fixed_asset"
+					):
+						item.set("is_fixed_asset", ret.get("is_fixed_asset", 0))
+
+					# Double check for cost center
+					# Items add via promotional scheme may not have cost center set
+					if hasattr(item, "cost_center") and not item.get("cost_center"):
+						item.set(
+							"cost_center",
+							self.get("cost_center") or get_default_cost_center(self.company),
+						)
+
+					if ret.get("pricing_rules"):
+						self.apply_pricing_rule_on_items(item, ret)
+						self.set_pricing_rule_details(item, ret)
+				else:
+					# Transactions line item without item code
+
+					uom = item.get("uom")
+					stock_uom = item.get("stock_uom")
+					if bool(uom) != bool(stock_uom):  # xor
+						item.stock_uom = item.uom = uom or stock_uom
+
+					# UOM cannot be zero so substitute as 1
+					item.conversion_factor = (
+						get_uom_conv_factor(item.get("uom"), item.get("stock_uom"))
+						or item.get("conversion_factor")
+						or 1
+					)
+
+			if self.doctype == "Purchase Invoice":
+				self.set_expense_account(for_validate)
 
 
 @frappe.whitelist()
@@ -225,7 +353,7 @@ def make_sales_invoices(docname: str, rows: list | str) -> None:
 @frappe.whitelist()
 def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=True):
 	"""
-	HASH: 59b9b7dc9185fee1814d5ef7d89d0875fead4bf7
+	HASH: af21bca2318089bfee543fdf2180e9d55c7f2833
 	REPO: https://github.com/frappe/erpnext/
 	PATH: erpnext/stock/get_item_details.py
 	METHOD: get_item_details
@@ -243,7 +371,7 @@ def get_item_details(args, doc=None, for_validate=False, overwrite_warehouse=Tru
 @frappe.whitelist()
 def validate_item_details(args, item):
 	"""
-	HASH: 59b9b7dc9185fee1814d5ef7d89d0875fead4bf7
+	HASH: af21bca2318089bfee543fdf2180e9d55c7f2833
 	REPO: https://github.com/frappe/erpnext/
 	PATH: erpnext/stock/get_item_details.py
 	METHOD: validate_item_details

--- a/inventory_tools/inventory_tools/overrides/purchase_receipt.py
+++ b/inventory_tools/inventory_tools/overrides/purchase_receipt.py
@@ -10,7 +10,7 @@ from frappe.utils.data import cint
 class InventoryToolsPurchaseReceipt(PurchaseReceipt):
 	def validate_with_previous_doc(self):
 		"""
-		HASH: 427439c3f19bfd1401628cf39a30ddd291dbfec7
+		HASH: 9daabfca8a3dc4d940d02bf218cfd02605dbde0f
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/stock/doctype/purchase_receipt/purchase_receipt.py
 		METHOD: validate_with_previous_doc

--- a/inventory_tools/inventory_tools/overrides/stock_entry.py
+++ b/inventory_tools/inventory_tools/overrides/stock_entry.py
@@ -12,7 +12,7 @@ from inventory_tools.inventory_tools.overrides.work_order import get_allowance_p
 class InventoryToolsStockEntry(StockEntry):
 	def check_if_operations_completed(self):
 		"""
-		HASH: 54791e938bd56eb81f7d8d923381a006998919fe
+		HASH: 32bfc2f5553661c2ba46109e6b22bdbea963a108
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/stock/doctype/stock_entry/stock_entry.py
 		METHOD: check_if_operations_completed
@@ -54,7 +54,7 @@ class InventoryToolsStockEntry(StockEntry):
 
 	def validate_finished_goods(self):
 		"""
-		HASH: 54791e938bd56eb81f7d8d923381a006998919fe
+		HASH: 32bfc2f5553661c2ba46109e6b22bdbea963a108
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/stock/doctype/stock_entry/stock_entry.py
 		METHOD: validate_finished_goods
@@ -120,7 +120,7 @@ class InventoryToolsStockEntry(StockEntry):
 
 	def get_pending_raw_materials(self, backflush_based_on=None):
 		"""
-		HASH: 54791e938bd56eb81f7d8d923381a006998919fe
+		HASH: 32bfc2f5553661c2ba46109e6b22bdbea963a108
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/stock/doctype/stock_entry/stock_entry.py
 		METHOD: get_pending_raw_materials

--- a/inventory_tools/inventory_tools/overrides/warehouse.py
+++ b/inventory_tools/inventory_tools/overrides/warehouse.py
@@ -47,7 +47,7 @@ def update_warehouse_path(doc, method=None) -> None:
 @frappe.whitelist()
 def warehouse_query(doctype, txt, searchfield, start, page_len, filters):
 	"""
-	HASH: 2c9b3908dd61ae51e9c455dc0b4b03fd69ea15c0
+	HASH: 74220430e537c40ca6b0af1dffe0412f23ef8c99
 	REPO: https://github.com/frappe/erpnext/
 	PATH: erpnext/controllers/queries.py
 	METHOD: warehouse_query

--- a/inventory_tools/inventory_tools/overrides/work_order.py
+++ b/inventory_tools/inventory_tools/overrides/work_order.py
@@ -17,7 +17,7 @@ from frappe.utils import cint, flt, get_link_to_form, getdate
 class InventoryToolsWorkOrder(WorkOrder):
 	def onload(self):
 		"""
-		HASH: ef2553edf967612bdbf580357d5886c6afacaea2
+		HASH: 46a2b7a07e5326ad5fde89d030460a5e9f2b67b0
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/work_order/work_order.py
 		METHOD: onload
@@ -113,7 +113,7 @@ class InventoryToolsWorkOrder(WorkOrder):
 
 	def update_work_order_qty(self):
 		"""
-		HASH: ef2553edf967612bdbf580357d5886c6afacaea2
+		HASH: 46a2b7a07e5326ad5fde89d030460a5e9f2b67b0
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/work_order/work_order.py
 		METHOD: update_work_order_qty
@@ -159,7 +159,7 @@ class InventoryToolsWorkOrder(WorkOrder):
 
 	def update_operation_status(self):
 		"""
-		HASH: ef2553edf967612bdbf580357d5886c6afacaea2
+		HASH: 46a2b7a07e5326ad5fde89d030460a5e9f2b67b0
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/work_order/work_order.py
 		METHOD: update_operation_status
@@ -182,7 +182,7 @@ class InventoryToolsWorkOrder(WorkOrder):
 
 	def validate_qty(self):
 		"""
-		HASH: ef2553edf967612bdbf580357d5886c6afacaea2
+		HASH: 46a2b7a07e5326ad5fde89d030460a5e9f2b67b0
 		REPO: https://github.com/frappe/erpnext/
 		PATH: erpnext/manufacturing/doctype/work_order/work_order.py
 		METHOD: validate_qty

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,10 @@ indent = "\t"
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:tool.poetry.version"]
+version_variables = [
+    "inventory_tools/__init__.py:__version__"
+]
+build_command = "echo 1"
 
 [tool.semantic_release.branches.version]
 match = "version-(14|15)"


### PR DESCRIPTION
Closes #115 

Removes the global monkey in the `__init__.py` with a targeted method override in Purchase Order.

The background of this issue is that the simple whitelisted method override technique didn't cover the case when the user was in a Work Order for a subcontracted item (the 2nd Pie Crust BOM), and clicked the "Create Subcontracting PO" button. The chain of code calls under the hood to map to the new doc used the ERPNext methods server-side, so it would trigger a validation error that the item (Pie Crust) had to be a non-stock item.

This PR replaces the global override of the problematic method with a full copy of the accounts_controller.py's `set_missing_item_details` so it uses the Inventory Tools version vs the ERPNext one.
