### PR TITLE
chore: adjust customize.py for removed keys in custom.json files

### DIFF
--- a/inventory_tools/customize.py
+++ b/inventory_tools/customize.py
@@ -28,7 +28,8 @@ def load_customizations():
 				if existing_field
 				else frappe.new_doc("Custom Field")
 			)
-			field.pop("modified")
+			if field.get("modified"):
+				field.pop("modified")
 			{custom_field.set(key, value) for key, value in field.items()}
 			custom_field.flags.ignore_permissions = True
 			custom_field.flags.ignore_version = True


### PR DESCRIPTION
Minor update here - the test_utils clean customizations hook removes the `modified` key, so on a `bench migrate` I get an error when `customize.py` tries to pop that field. This change checks for the field first to avoid a key error.