### PR TITLE
fix: workstation op cost feature adjustments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
           - tomli
 
   - repo: https://github.com/agritheory/test_utils
-    rev: v1.3.2
+    rev: v1.4.1
     hooks:
       - id: update_pre_commit_config
       - id: mypy

--- a/inventory_tools/inventory_tools/doctype/workstation_operating_cost/workstation_operating_cost.py
+++ b/inventory_tools/inventory_tools/doctype/workstation_operating_cost/workstation_operating_cost.py
@@ -103,7 +103,14 @@ def get_operating_costs_by_operation(
 			continue
 
 		ws = frappe.get_doc("Workstation", op.workstation)
-		hours = flt(op.time_in_mins) / 60.0
+		jc_filters = {
+			"work_order": work_order.name,
+			"workstation": op.workstation,
+			"operation": op.operation,
+			"status": "Completed",
+		}
+		jc_time_in_mins = frappe.get_value("Job Card", jc_filters, "total_time_in_mins")
+		hours = (jc_time_in_mins or flt(op.time_in_mins)) / 60.0
 
 		if ws.workstation_operating_cost:
 			for row in ws.workstation_operating_cost:
@@ -123,7 +130,7 @@ def get_operating_costs_by_operation(
 
 					qty = flt(work_order.qty)
 					if qty:
-						cost_per_unit = flt(total_cost / qty, 2)
+						cost_per_unit = total_cost / qty
 
 						operation_name = op.operation or ws.workstation_name or ws.name
 						account_short = row.account.split(" - ")[0] if " - " in row.account else row.account
@@ -148,7 +155,7 @@ def get_operating_costs_by_operation(
 						)
 		else:
 			account = frappe.db.get_value("Company", ws.company, "expenses_included_in_valuation")
-			cost_per_unit = flt((ws.hour_rate * hours) / flt(work_order.qty), 2)
+			cost_per_unit = (ws.hour_rate * hours) / flt(work_order.qty)
 			operating_costs.append(
 				frappe._dict(
 					{

--- a/inventory_tools/inventory_tools/overrides/stock_entry.py
+++ b/inventory_tools/inventory_tools/overrides/stock_entry.py
@@ -194,6 +194,7 @@ class InventoryToolsStockEntry(StockEntry):
 	def calculate_additional_costs(stock_entry=None, work_order=None):
 		from erpnext.manufacturing.doctype.bom.bom import add_non_stock_items_cost
 
+		print("IN INV TOOLS CALCULATE_ADDITIONAL_COSTS")
 		# Add non stock items cost in the additional cost
 		stock_entry.additional_costs = []
 		company_account = frappe.db.get_value(
@@ -225,8 +226,6 @@ def add_operations_cost(stock_entry, work_order=None, expense_account=None):
 					"amount": flt(cost.get("cost_per_unit")) * flt(stock_entry.fg_completed_qty),
 				},
 			)
-	else:
-		super().calculate_additional_costs(stock_entry, work_order)
 
 	if work_order and work_order.additional_operating_cost and work_order.qty:
 		additional_operating_cost_per_unit = flt(work_order.additional_operating_cost) / flt(

--- a/inventory_tools/inventory_tools/overrides/stock_entry.py
+++ b/inventory_tools/inventory_tools/overrides/stock_entry.py
@@ -194,7 +194,6 @@ class InventoryToolsStockEntry(StockEntry):
 	def calculate_additional_costs(stock_entry=None, work_order=None):
 		from erpnext.manufacturing.doctype.bom.bom import add_non_stock_items_cost
 
-		print("IN INV TOOLS CALCULATE_ADDITIONAL_COSTS")
 		# Add non stock items cost in the additional cost
 		stock_entry.additional_costs = []
 		company_account = frappe.db.get_value(


### PR DESCRIPTION
This PR makes the following tweaks for the Workstation Operating Costs feature to work with a client's installation:

- checks for a Job Card to get accurate `time_in_mins` for an operation, falls back to the Work Order value if 0 or doesn't exist
- removes the rounding to 2 decimal places on the workstation op cost calc for the cost per unit. Some costs are very small per unit and get zeroed out with this precision here - instead, it now leaves the value as-calculated and the precision gets applied in the downstream field that uses the operating costs
- removes a call to `super().calculate_additional_costs(stock_entry, work_order)` - there is no method up the Stock Entry inheritance chain (looks like it's only defined in the Subcontracting classes, which Stock Entry doesn't inherit from)